### PR TITLE
terranix: Increase EC2 storage from 50GB to 100GB

### DIFF
--- a/modules/terranix/default.nix
+++ b/modules/terranix/default.nix
@@ -82,7 +82,7 @@ in
     key_name = config.resource.aws_key_pair.deployer.key_name;
     iam_instance_profile = "\${aws_iam_instance_profile.chutney_profile.id}";
     root_block_device = {
-      volume_size = 50; # In GB
+      volume_size = 100; # In GB
       volume_type = "gp3";
       iops = 3000;
     };


### PR DESCRIPTION
Postgresql service was failing to start due to low disk space:
```sh
Sep 05 11:00:14 chutney postgres[455203]: [455203] FATAL:  could not access status of transaction 0
Sep 05 11:00:14 chutney postgres[455203]: [455203] DETAIL:  Could not write to file "pg_multixact/members/0353" at offset 16384: No space left on device.
Sep 05 11:00:14 chutney postgres[455203]: [455203] CONTEXT:  WAL redo at 79/9F206FD8 for MultiXact/ZERO_MEM_PAGE: 27234
Sep 05 11:00:14 chutney postgres[196210]: [196210] LOG:  startup process (PID 455203) exited with exit code 1
Sep 05 11:00:14 chutney postgres[196210]: [196210] LOG:  terminating any other active server processes
Sep 05 11:00:14 chutney postgres[196210]: [196210] LOG:  shutting down due to startup process failure
Sep 05 11:00:14 chutney postgres[196210]: [196210] LOG:  database system is shut down
Sep 05 11:00:14 chutney systemd[1]: postgresql.service: Main process exited, code=exited, status=1/FAILURE
```

`df -h` output:
```sh
Filesystem                Size  Used Avail Use% Mounted on
devtmpfs                  390M     0  390M   0% /dev
tmpfs                     3.9G  1.1M  3.9G   1% /dev/shm
tmpfs                     2.0G  7.3M  1.9G   1% /run
/dev/disk/by-label/nixos   49G   44G  3.3G  93% /
efivarfs                  128K  2.6K  126K   3% /sys/firmware/efi/efivars
tmpfs                     1.0M     0  1.0M   0% /run/credentials/systemd-tmpfiles-setup-dev-early.service
tmpfs                     1.0M     0  1.0M   0% /run/credentials/systemd-tmpfiles-setup-dev.service
tmpfs                     3.9G  2.2M  3.9G   1% /run/wrappers
/dev/nvme0n1p1            236M   84M  153M  36% /boot
tmpfs                     1.0M     0  1.0M   0% /run/credentials/systemd-tmpfiles-setup.service
tmpfs                     1.0M     0  1.0M   0% /run/credentials/systemd-journald.service
tmpfs                     780M  4.0K  780M   1% /run/user/0
```

resolves #46 